### PR TITLE
Add functionality to delete shipping addresses

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -121,3 +121,12 @@ def email_preferences(request):
             'profile': profile,
         }
         return render(request, 'accounts/email_preferences.html', context)
+
+@login_required
+def delete_shipping_address(request, address_id):
+    try:
+        address = ShippingAddress.objects.get(id=address_id, user=request.user)
+        address.delete()
+    except ShippingAddress.DoesNotExist:
+        pass  # Address not found or not owned by user, silently redirect
+    return redirect('profile')

--- a/estore/templates/accounts/profile.html
+++ b/estore/templates/accounts/profile.html
@@ -39,7 +39,7 @@
                                     <a href="#" class="btn btn-sm btn-outline-secondary">Set as Default</a>
                                 {% endif %}
                                 <a href="{% url 'edit_shipping_address' address_id=address.id %}" class="btn btn-sm btn-outline-primary">Edit</a>
-                                <a href="#" class="btn btn-sm btn-outline-danger">Delete</a>
+                                <a href="{% url 'delete_shipping_address' address_id=address.id %}" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this address?');">Delete</a>
                             </div>
                             <hr>
                         {% endfor %}

--- a/estore/urls.py
+++ b/estore/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from accounts.views import profile, add_shipping_address, edit_shipping_address, edit_profile, email_preferences
+from accounts.views import profile, add_shipping_address, edit_shipping_address, edit_profile, email_preferences, delete_shipping_address
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -27,6 +27,7 @@ urlpatterns = [
     path('accounts/profile/', profile, name='profile'),
     path('accounts/profile/add-address/', add_shipping_address, name='add_shipping_address'),
     path('accounts/profile/edit-address/<int:address_id>/', edit_shipping_address, name='edit_shipping_address'),
+    path('accounts/profile/delete-address/<int:address_id>/', delete_shipping_address, name='delete_shipping_address'),
     path('accounts/profile/edit/', edit_profile, name='edit_profile'),
     path('accounts/profile/email-preferences/', email_preferences, name='email_preferences'),
     path('promotions/', include('promotions.urls')),


### PR DESCRIPTION
This commit introduces a new feature allowing users to delete their shipping addresses from their profile. It includes:
- A new view `delete_shipping_address` in `accounts/views.py` to handle the deletion logic, ensuring only the user's own addresses can be deleted.
- An updated template in `accounts/profile.html` with a confirmation prompt for the delete action.
- A new URL pattern in `estore/urls.py` to map the delete action to the corresponding view.